### PR TITLE
Added requestEncoding as Property to WMTS Source

### DIFF
--- a/src/components/sources/SourceWMTS.vue
+++ b/src/components/sources/SourceWMTS.vue
@@ -129,6 +129,10 @@ export default {
         dimensions: {
             type: Object
         },
+        requestEncoding: {
+            type: String,
+            default: "KVP",
+        },
         url: {
             type: String
         },


### PR DESCRIPTION
The requestEncoding Property, supported by OpenLayers, was not available for the WMTS Source Component.

## Description
I added the requestEncoding property to the WMTS Source Component.
Because every prop from the Component is forwarded to the OpenLayers WMTS Class, i only needed to declare it in the props Section.

## Motivation and Context
We have an WMTS for our Application. But it only has a REST API, so KVP, wich was default, was not working.

## How Has This Been Tested?
We included the npm package from our local source, is working fine.

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

I didn't found out where the Docs are maintained, would just need to add this Prop.

Thank you for your amazing work!

Best regards,
Dominic