### PR TITLE
Added time parameter to ol-source-image-wms

### DIFF
--- a/src/components/sources/SourceImageWMS.vue
+++ b/src/components/sources/SourceImageWMS.vue
@@ -32,7 +32,8 @@ export default {
                 ...properties,
                 params: {
                     'LAYERS': props.layers,
-                    'STYLES': props.styles
+                    'STYLES': props.styles,
+                    'TIME': props.time
                     },
                 projection: typeof properties.projection == "string" ? properties.projection : new Projection({
                     ...properties.projection
@@ -105,6 +106,9 @@ export default {
         styles: {
             type: [String,Array],
             default: ''
+        },
+        time: {
+            type: String
         },
         ratio: {
             type: Number,


### PR DESCRIPTION
Time Dimension for WMS Layers

## Description
Some WMS have a time dimension as well. This PR adds this functionality as an optional string prop to the SourceImageWMS component. 

## Motivation and Context
Missing functionality

## How Has This Been Tested?
Tested the functionality on a private WMS. Works with and without a time prop.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.