### PR TITLE
Adds TileGrid

### DIFF
--- a/src/components/sources/SourceXYZ.vue
+++ b/src/components/sources/SourceXYZ.vue
@@ -94,7 +94,10 @@ export default {
         },
         transition: {
             type: Number
-        }
+        },
+        tileGrid: {
+            type: Object,
+        },
     }
 }
 </script>


### PR DESCRIPTION
I've added the TileGrid as a property for the SourceXYZ component.

## Motivation and Context
These changes made it possible for us to use the TileGrid and therefore custom xyz-sources.
For it to work you will have to create a new OL TileGrid instead of a plain object, so:
const tileGrid = new TileGrid({
...
});
instead of
const TileGrid = {
...
};

## How Has This Been Tested?
We were able to use TileGrids successfully with this solution. But I am by no means an OL expert, so please test it for yourself if I missed anything :)

## Types of Changes
I just added the TileGrid as a regular property for the SourceXYZ component like documented in the OL API:
https://openlayers.org/en/latest/apidoc/module-ol_source_XYZ-XYZ.html

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -> No - where can I do that? 