### PR TITLE
WIP: Typescript types declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,22 @@
+declare module 'vue3-openlayers' {
+  import {App} from 'vue';
+  import feature from 'ol/Feature';
+  import * as geom from 'ol/geom/';
+  import * as format from 'ol/format';
+  import * as loadingstrategy from 'ol/loadingstrategy';
+  import * as selectconditions from 'ol/events/condition';
+  import * as extent from 'ol/extent';
+  import * as animations from 'ol/easing';
+
+  module '@vue/runtime-core' {
+    export declare function inject(key: 'ol-feature'): typeof feature
+    export declare function inject(key: 'ol-geom'): typeof geom
+    export declare function inject(key: 'ol-animations'): typeof animations
+    export declare function inject(key: 'ol-format'): typeof format
+    export declare function inject(key: 'ol-loadingstrategy'): typeof loadingstrategy
+    export declare function inject(key: 'ol-selectconditions'): typeof selectconditions
+    export declare function inject(key: 'ol-extent'): typeof extent
+  }
+
+  export default function install(app: App): void
+}

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
     "lint": "vue-cli-service lint"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "index.d.ts"
   ],
+  "types": "index.d.ts",
   "dependencies": {
     "core-js": "^3.6.5",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
Added basic typescript declaration for the module.

## Description
  * Created typescript declaration file
  * Added declarations that declare return values of the `inject` method provided by the plugin.

## Motivation and Context
When using a module with typescript there are some types missing and can be declared.

## How Has This Been Tested?
Created new Nuxt 3 plugin, with next code:
```typescript
import OpenLayersMap from 'vue3-openlayers'
import 'vue3-openlayers/dist/vue3-openlayers.css'

export default defineNuxtPlugin((nuxtApp) => {
  nuxtApp.vueApp.use(OpenLayersMap)
})
```

Then created a component with example code:
```typescript
export default {
  setup() {
    const center = ref([34, 39.13])
    const projection = ref('EPSG:4326')
    const zoom = ref(6)
    const rotation = ref(0)

    const format = inject('ol-format');

    const geoJson = new format.GeoJSON();
   ...
```

Without the types declarations, the type of `format` is `unknown`.
With the declarations, the types properly resolved to the `ol` types.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix: Typescript types declarations