### PR TITLE
Added `imageLoadFunction` prop definition to `SourceImageWMS`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue3-openlayers",
-  "version": "0.1.66",
+  "version": "0.1.68",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue3-openlayers",
-      "version": "0.1.66",
+      "version": "0.1.68",
       "license": "MIT",
       "dependencies": {
         "file-saver": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "prepare": "npm run build"
   },
   "files": [
     "dist/*",

--- a/src/components/sources/SourceImageWMS.vue
+++ b/src/components/sources/SourceImageWMS.vue
@@ -95,6 +95,9 @@ export default {
             type: String,
             default: 'mapserver'
         },
+        imageLoadFunction: {
+            type: Function
+        },
         imageSmoothing: {
             type: Boolean,
             default: true


### PR DESCRIPTION
## Description
As per the [official documentation](https://vue3openlayers.netlify.app/componentsguide/sources/imagewms/#imageloadfunction) `ol-source-image-wms` component should support an optional `Function` prop named `imageLoadFunction`. This property is [supported](https://openlayers.org/en/latest/apidoc/module-ol_source_ImageWMS.html) by `ol/source/ImageWMS` and simply adding a definition in the Vue component fixes the issue.
This fix just adds the prop definition in the `SourceImageWMS` component, the component's setup step already takes care of passing the defined and used props to `ol/source/ImageWMS`.

## Motivation and Context
Without defining the supported prop under the component will prevent it from being passed to the `OpenLayers` module, even if it is set in the component's instance.

## How Has This Been Tested?
It has been tested with the [relative documentation's example](https://vue3openlayers.netlify.app/componentsguide/sources/imagewms/) setting the `imageLoadFunction` prop to a function that fetches the generated url adding auth headers and setting the image src with the relative base64 data.
It can be tested with a simple function that just logs in console and sets the src with the given one [as the default behavior](https://openlayers.org/en/latest/apidoc/module-ol_Image.html#~LoadFunction).
``` ts
import { ImageTile } from "ol";

function testImageLoadFunction (tile: ImageTile, src: string): void {
  //TODO log here
  tile.getImage().src = src;
}
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.