### PR TITLE
`hitTolerance` support

### DIFF
--- a/src/components/interaction/SelectInteraction.vue
+++ b/src/components/interaction/SelectInteraction.vue
@@ -81,7 +81,12 @@ export default {
         },
         features: {
             type: [Collection,Object]
-        }
+        },
+        hitTolerance: {
+            type: Number,
+            default: 0,
+            validator: value => value >= 0,
+        },
     }
 
 }


### PR DESCRIPTION
## Description

This MR adds support for `hitTolerance`:
>Hit-detection tolerance. Pixels inside the radius around the given position will be checked for features.
(from [ol docs](https://openlayers.org/en/latest/apidoc/module-ol_interaction_Select-Select.html))

## Motivation and Context
It's a useful feature when interacting with multiple layers/geometries.

## How Has This Been Tested?
Was not tested.

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -> I would but I'm not sure how to