### PR TITLE
removeCondition support in SelectInteraction

### DIFF
--- a/src/components/interaction/SelectInteraction.vue
+++ b/src/components/interaction/SelectInteraction.vue
@@ -87,6 +87,9 @@ export default {
             default: 0,
             validator: value => value >= 0,
         },
+        removeCondition: {
+            type: Function,
+        }
     }
 
 }


### PR DESCRIPTION
This MR adds support for `removeCondition`:

>A function that takes an MapBrowserEvent and returns a boolean to indicate whether that event should be handled. By default, this is never. Use this if you want to use different events for add and remove instead of toggle.

(from [ol docs](https://openlayers.org/en/latest/apidoc/module-ol_interaction_Select-Select.html))

## Motivation and Context
It's a useful feature when interacting specific feature for which the select interaction should not be allowed

## How Has This Been Tested?
Was not tested.

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -> I would but I'm not sure how to