### PR TITLE
Let the SourceWMTS component accept a tile grid as prop instead of calculating one

### DIFF
--- a/docs/componentsguide/sources/wmts/index.md
+++ b/docs/componentsguide/sources/wmts/index.md
@@ -126,6 +126,12 @@ WMTS version.
 
 Matrix set.
 
+### tileGrid
+
+- **Type**: `ol/tilegrid/TileGrid`
+
+An optional tile grid object. If not given, a tile grid will be generated from the `projection` and `tileZoomLevel` properties.
+
 ### dimensions
 
 - **Type**: `Object`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Instead of calculating a tile grid from the projection extent and the tile zoom level, the SourceWMTS now accepts a tile grid directly as a prop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #134. It should be possible to pass a tile grid directly. In my case it was essential, because I have a tile grid but my projection doesn't have an extent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have done the same change in a local copy of the SourceWMTS component, placed it directly in my JS project and it works well there. (I'd like to test using this branch as the npm dependency, but I'm not sure how to do it.)

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.