### PR TITLE
MapControls: Added missing RotateControl export

### DIFF
--- a/src/components/mapControls/index.js
+++ b/src/components/mapControls/index.js
@@ -57,6 +57,7 @@ export {
   ZoomControl,
   ZoomSliderControl,
   ZoomToExtentControl,
+  RotateControl,
   ContextMenuControl,
   SwipeControl,
   ControlBar,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added missing MapControls RotateControl export.

## Motivation and Context

Allows RotateControl to be imported from the MapControls space.
Relates to https://github.com/MelihAltintas/vue3-openlayers/issues/131#issuecomment-1487525511

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other (Tooling, Dependency Updates, etc.)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.