### PR TITLE
Add ol-vector-image-layer component

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -77,6 +77,10 @@ export default defineConfig({
             link: "/componentsguide/layers/tilelayer/",
           },
           {
+            text: "ol-vector-image-layer",
+            link: "/componentsguide/layers/vectorimagelayer/",
+          },
+          {
             text: "ol-vector-layer",
             link: "/componentsguide/layers/vectorlayer/",
           },

--- a/docs/componentsguide/layers/vectorimagelayer/index.md
+++ b/docs/componentsguide/layers/vectorimagelayer/index.md
@@ -1,0 +1,149 @@
+# ol-vector-image-layer
+
+ol-vector-image-layer can render vector from various backend services. It should be used with together with ol-source-vector component.
+
+<script setup>
+import VectorSourceDemo1 from "@demos/VectorSourceDemo1.vue"
+</script>
+
+<ClientOnly>
+<VectorSourceDemo1 />
+</ClientOnly>
+
+## Usage
+
+Example below shows how you can use ol-vector-layer and ol-source-vector to render some vector features from remote backend.
+
+Load features simply by providing url value and format GeoJSON
+
+```vue
+<template>
+  <ol-map
+    :loadTilesWhileAnimating="true"
+    :loadTilesWhileInteracting="true"
+    style="height:400px"
+  >
+    <ol-view
+      ref="view"
+      :center="center"
+      :rotation="rotation"
+      :zoom="zoom"
+      :projection="projection"
+    />
+
+    <ol-tile-layer>
+      <ol-source-osm />
+    </ol-tile-layer>
+
+    <ol-vector-image-layer>
+      <ol-source-vector :url="url" :format="geoJson"> </ol-source-vector>
+    </ol-vector-image-layer>
+  </ol-map>
+</template>
+
+<script>
+import { ref, inject } from "vue";
+export default {
+  setup() {
+    const center = ref([0, 0]);
+    const projection = ref("EPSG:4326");
+    const zoom = ref(3);
+    const rotation = ref(0);
+
+    const url = ref(
+      "https://openlayers.org/en/latest/examples/data/geojson/countries.geojson"
+    );
+
+    const format = inject("ol-format");
+    console.log(format);
+    const geoJson = new format.GeoJSON();
+
+    return {
+      center,
+      projection,
+      zoom,
+      rotation,
+      url,
+      geoJson,
+    };
+  },
+};
+</script>
+```
+
+## Properties
+
+### className
+
+- **Type**: `string`
+- **Default**: `ol-layer`
+
+A CSS class name to set to the layer element.
+
+### opacity
+
+- **Type**: `number `
+- **Default**: `1`
+
+Opacity (0, 1).
+
+### visible
+
+- **Type**: `boolean  `
+- **Default**: `true`
+
+Visibility.
+
+### extent
+
+- **Type**: `Array`
+
+The bounding extent for layer rendering. The layer will not be rendered outside of this extent.
+
+### zIndex
+
+- **Type**: `number`
+
+The z-index for layer rendering. At rendering time, the layers will be ordered, first by Z-index and then by position.
+
+### minResolution
+
+- **Type**: `number`
+
+The minimum resolution (inclusive) at which this layer will be visible.
+
+### maxResolution
+
+- **Type**: `number`
+
+The maximum resolution (exclusive) below which this layer will be visible.
+
+### minZoom
+
+- **Type**: `number`
+
+The minimum view zoom level (exclusive) above which this layer will be visible.
+
+### maxZoom
+
+- **Type**: `number`
+
+The maximum view zoom level (inclusive) at which this layer will be visible.
+
+### renderBuffer
+
+- **Type**: `number`
+- **Default**: `100`
+  The buffer in pixels around the viewport extent used by the renderer when getting features from the vector source for the rendering or hit-detection. Recommended value: the size of the largest symbol, line width or label.
+
+### updateWhileAnimating
+
+- **Type**: `Boolean`
+- **Default**: `false`
+  When set to true, feature batches will be recreated during animations. This means that no vectors will be shown clipped, but the setting will have a performance impact for large amounts of vector data. When set to false, batches will be recreated when no animation is active.
+
+### updateWhileInteracting
+
+- **Type**: `Boolean`
+- **Default**: `false`
+  When set to true, feature batches will be recreated during interactions. See also updateWhileAnimating.

--- a/docs/componentsguide/layers/vectorimagelayer/index.md
+++ b/docs/componentsguide/layers/vectorimagelayer/index.md
@@ -2,12 +2,14 @@
 
 ol-vector-image-layer can render vector from various backend services. It should be used with together with ol-source-vector component.
 
+Vector data is rendered client-side, to an image, which yields much better performance than ol-vector-layer during panning and zooming operations, but point symbols and texts are always rotated with the view and pixels are scaled during zoom animations.
+
 <script setup>
-import VectorSourceDemo1 from "@demos/VectorSourceDemo1.vue"
+import VectorSourceDemo4 from "@demos/VectorSourceDemo4.vue"
 </script>
 
 <ClientOnly>
-<VectorSourceDemo1 />
+<VectorSourceDemo4 />
 </ClientOnly>
 
 ## Usage

--- a/docs/componentsguide/layers/vectorimagelayer/index.md
+++ b/docs/componentsguide/layers/vectorimagelayer/index.md
@@ -52,9 +52,7 @@ export default {
     const zoom = ref(3);
     const rotation = ref(0);
 
-    const url = ref(
-      "https://openlayers.org/en/latest/examples/data/geojson/countries.geojson"
-    );
+    const url = ref("https://openlayers.org/data/vector/ecoregions.json");
 
     const format = inject("ol-format");
     console.log(format);

--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -58,6 +58,11 @@
   <priority>0.80</priority>
 </url>
 <url>
+  <loc>https://vue3openlayers.netlify.app/componentsguide/layers/vectorimagelayer/</loc>
+  <lastmod>2023-04-01T14:14:05+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
   <loc>https://vue3openlayers.netlify.app/componentsguide/layers/vectorlayer/</loc>
   <lastmod>2021-08-15T21:05:05+00:00</lastmod>
   <priority>0.80</priority>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue3-openlayers",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Openlayers Wrapper for Vue3",
   "repository": {
     "type": "git",

--- a/src/components/layers/VectorImageLayer.vue
+++ b/src/components/layers/VectorImageLayer.vue
@@ -1,0 +1,63 @@
+<template lang="">
+  <div>
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+import { inject, provide, onUnmounted, onMounted, watch, computed } from "vue";
+
+import VectorImageLayer from "ol/layer/VectorImage";
+import usePropsAsObjectProperties from "@/composables/usePropsAsObjectProperties";
+
+import BaseLayer from "./BaseLayer.vue";
+export default {
+  extends: BaseLayer,
+  name: "ol-vector-image-layer",
+  setup(props) {
+    const map = inject("map");
+
+    const { properties } = usePropsAsObjectProperties(props);
+
+    const vectorImageLayer = computed(() => new VectorImageLayer(properties));
+
+    watch(properties, () => {
+      vectorImageLayer.value.setProperties(properties);
+    });
+
+    onMounted(() => {
+      map.addLayer(vectorImageLayer.value);
+    });
+
+    onUnmounted(() => {
+      map.removeLayer(vectorImageLayer.value);
+    });
+
+    provide("vectorLayer", vectorImageLayer);
+    provide("stylable", vectorImageLayer);
+
+    return {
+      vectorImageLayer,
+    };
+  },
+  props: {
+    renderBuffer: {
+      type: Number,
+      default: 100,
+    },
+    updateWhileAnimating: {
+      type: Boolean,
+      default: false,
+    },
+    styles: {
+      type: [String, Array, Function],
+    },
+    updateWhileInteracting: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>
+
+<style lang=""></style>

--- a/src/components/layers/index.js
+++ b/src/components/layers/index.js
@@ -1,6 +1,7 @@
 import TileLayer from "./TileLayer.vue";
 import WebGLTileLayer from "./WebGLTileLayer.vue";
 import ImageLayer from "./ImageLayer.vue";
+import VectorImageLayer from "./VectorImageLayer.vue";
 import VectorLayer from "./VectorLayer.vue";
 import AnimatedClusterLayer from "./AnimatedClusterLayer.vue";
 import WebglPointsLayer from "./WebglPointsLayer.vue";
@@ -16,6 +17,7 @@ function install(app) {
   app.component(TileLayer.name, TileLayer);
   app.component(WebGLTileLayer.name, WebGLTileLayer);
   app.component(ImageLayer.name, ImageLayer);
+  app.component(VectorImageLayer.name, VectorImageLayer);
   app.component(VectorLayer.name, VectorLayer);
   app.component(AnimatedClusterLayer.name, AnimatedClusterLayer);
   app.component(WebglPointsLayer.name, WebglPointsLayer);
@@ -29,6 +31,7 @@ export {
   TileLayer,
   WebGLTileLayer,
   ImageLayer,
+  VectorImageLayer,
   VectorLayer,
   AnimatedClusterLayer,
   WebglPointsLayer,

--- a/src/components/sources/SourceWMTS.vue
+++ b/src/components/sources/SourceWMTS.vue
@@ -135,7 +135,7 @@ export default {
     },
     tileMatrixPrefix: {
       type: String,
-      default: ''
+      default: "",
     },
     styles: {
       type: [String, Array, Function],

--- a/src/demos/VectorSourceDemo4.vue
+++ b/src/demos/VectorSourceDemo4.vue
@@ -31,9 +31,7 @@ export default {
     const zoom = ref(3);
     const rotation = ref(0);
 
-    const url = ref(
-      "https://openlayers.org/en/latest/examples/data/geojson/countries.geojson"
-    );
+    const url = ref("https://openlayers.org/data/vector/ecoregions.json");
     const format = inject("ol-format");
     console.log(format);
     const geoJson = new format.GeoJSON();

--- a/src/demos/VectorSourceDemo4.vue
+++ b/src/demos/VectorSourceDemo4.vue
@@ -1,0 +1,51 @@
+<template>
+  <ol-map
+    :loadTilesWhileAnimating="true"
+    :loadTilesWhileInteracting="true"
+    style="height: 400px"
+  >
+    <ol-view
+      ref="view"
+      :center="center"
+      :rotation="rotation"
+      :zoom="zoom"
+      :projection="projection"
+    />
+
+    <ol-tile-layer>
+      <ol-source-osm />
+    </ol-tile-layer>
+
+    <ol-vector-image-layer>
+      <ol-source-vector :url="url" :format="geoJson"> </ol-source-vector>
+    </ol-vector-image-layer>
+  </ol-map>
+</template>
+
+<script>
+import { ref, inject } from "vue";
+export default {
+  setup() {
+    const center = ref([0, 0]);
+    const projection = ref("EPSG:4326");
+    const zoom = ref(3);
+    const rotation = ref(0);
+
+    const url = ref(
+      "https://openlayers.org/en/latest/examples/data/geojson/countries.geojson"
+    );
+    const format = inject("ol-format");
+    console.log(format);
+    const geoJson = new format.GeoJSON();
+
+    return {
+      center,
+      projection,
+      zoom,
+      rotation,
+      url,
+      geoJson,
+    };
+  },
+};
+</script>


### PR DESCRIPTION
This adds a `ol-vector-image-layer` component that serves as a wrapper around the [VectorImageLayer](https://openlayers.org/en/latest/apidoc/module-ol_layer_VectorImage-VectorImageLayer.html) layer class.

## Description

I added a new component that wraps the VectorImageLayer class and documentation for it.

## Motivation and Context

The VectorImageLayer layer type has a very similar interface to VectorLayer, but it renders all of its features to an image before drawing it on the map, which results in vastly improved performance during dragging/zooming operations.  This is very useful when rendering thousands of features at once.

## How Has This Been Tested?

I've deployed a working demo of this component here: https://hatchbed.github.io/vue3-openlayers/componentsguide/layers/vectorimagelayer/

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Other (Tooling, Dependency Updates, etc.)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

If you added a new component feature (layer, geom, source, etc.), please be sure to update the documentation:

- [x] Create a `src/demos/<Component>Demo.vue`
- [x] Create a `docs/componentsguide/<Category>/<Feature>/index.md` containing the Demo and documentation for the component
- [x] Add the docs page to `docs/.vitepress/config.ts`
- [x] Update the sitemap `docs/public/sitemap.xml`
