### PR TITLE
remove old draw-interaction, not new one

### DIFF
--- a/src/components/interaction/OlDrawInteraction.vue
+++ b/src/components/interaction/OlDrawInteraction.vue
@@ -91,31 +91,13 @@ const draw = computed(() => {
   return d;
 });
 
-watch(
-  [
-    type,
-    clickTolerance,
-    dragVertexDelay,
-    snapTolerance,
-    stopClick,
-    maxPoints,
-    minPoints,
-    finishCondition,
-    geometryFunction,
-    geometryName,
-    condition,
-    freehand,
-    freehandCondition,
-    wrapX,
-  ],
-  () => {
-    map?.removeInteraction(draw.value);
-    map?.addInteraction(draw.value);
-    draw.value.changed();
+watch(draw, (newVal, oldVal) => {
+  map?.removeInteraction(oldVal);
+  map?.addInteraction(newVal);
+  newVal.changed();
 
-    map?.changed();
-  }
-);
+  map?.changed();
+});
 
 onMounted(() => {
   map?.addInteraction(draw.value);


### PR DESCRIPTION
## Description

Fix Draw Interaction by correctly removing old interaction on changes, not new one.

## Motivation and Context

## How Has This Been Tested?

Not tested

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other (Tooling, Dependency Updates, etc.)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
