### PR TITLE
Fix #175 Interactions.click not working due to comparing different OL Feature instances by including ol as RollupOptions.External depenency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,12 @@
   "dependencies": {
     "file-saver": "^2.0.5",
     "jspdf": "^2.5.1",
+    "proj4": "^2.9.0"
+  },
+  "peerDependencies": {
     "ol": "^7.4.0",
     "ol-contextmenu": "^5.2.1",
-    "ol-ext": "^4.0.8",
-    "proj4": "^2.9.0"
+    "ol-ext": "^4.0.8"
   },
   "browserslist": [
     "> 1%",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
       input: {
         main: fileURLToPath(new URL("./src/index.ts", import.meta.url)),
       },
-      external: ["vue"],
+      external: ["vue", /^ol.*/], // Avoid bundling ol imports into the final build
       output: {
         inlineDynamicImports: true,
         exports: "named",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adding OpenLayer dependency as external dependency in RollupOptions avoids bundling OpenLayers.Feature into the `vue3-openlayers` dist file. This fixes the issue where Openlayers try to check if a feature is instance of OpenLayers.Feature, but return false as the feature is actually instanceof `LocalSourceCode.Feature`.

## Motivation and Context

See https://github.com/MelihAltintas/vue3-openlayers/issues/175#issuecomment-1629855104

## How Has This Been Tested?

Building the dist, copy into another project's node_modules. Rebuild dependencies in vite and checking that stuff works.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [?] Documentation Update
- [x] Other (Tooling, Dependency Updates, etc.)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [?] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


Please verify that this change does not affect how users install the library, it's too late in the evening for me to do this now.