### PR TITLE
Fix: OlFeature do not create a new Feature on props.properties change

### DIFF
--- a/src/components/map/OlFeature.vue
+++ b/src/components/map/OlFeature.vue
@@ -40,7 +40,6 @@ watch(
   () => {
     // Ensure the feature's properties are updated on change
     feature.value.setProperties(props.properties);
-    console.debug("feature changed", feature.value.getProperties().lat);
   }
 );
 

--- a/src/components/map/OlFeature.vue
+++ b/src/components/map/OlFeature.vue
@@ -4,13 +4,12 @@
 
 <script setup lang="ts">
 import type { Ref } from "vue";
-import { provide, inject, watch, onMounted, onUnmounted, computed } from "vue";
+import { provide, inject, watch, onMounted, onUnmounted, ref } from "vue";
 import Feature from "ol/Feature";
 import type Geometry from "ol/geom/Geometry";
 import type VectorSource from "ol/source/Vector";
 import type VectorLayer from "ol/layer/Vector";
 import type HeatmapLayer from "ol/layer/Heatmap";
-import usePropsAsObjectProperties from "@/composables/usePropsAsObjectProperties";
 import type { FeatureAnimation } from "@/components/animations/AnimationTypes";
 
 const props = withDefaults(
@@ -34,15 +33,16 @@ const animation = inject<Ref<FeatureAnimation | null> | null>(
   null
 );
 
-const { properties } = usePropsAsObjectProperties(props);
+const feature = ref<Feature<Geometry>>(new Feature({ ...props.properties }));
 
-const feature = computed(() => new Feature({ ...properties.properties }));
-
-watch(feature, (newVal, oldVal) => {
-  vectorSource?.value?.removeFeature(oldVal);
-  vectorSource?.value?.addFeature(newVal);
-  vectorSource?.value?.changed();
-});
+watch(
+  () => props.properties, // Needed as props.properties is optional
+  () => {
+    // Ensure the feature's properties are updated on change
+    feature.value.setProperties(props.properties);
+    console.debug("feature changed", feature.value.getProperties().lat);
+  }
+);
 
 watch(
   () => vectorSource,


### PR DESCRIPTION
Creating a new Feature results in removing any styling that has been applied to the feature. This can also be solved by adding more reactivity on the injected styledObj in OlStyle.

Please make sure that I do not break anything by removing the usage of `usePropsAsObjectProperties`. I did not figure out what it adds of value in this component. Is it possible to pass in the coordinates of the feature into the props.properties object? -> If so, then I break the functionality here

See https://github.com/MelihAltintas/vue3-openlayers/issues/128#issuecomment-1630472490 for details

Fixes #128
