### PR TITLE
feat(ol-style-text): added backgroundFill and backgroundStroke props

### DIFF
--- a/docs/componentsguide/styles/text/index.md
+++ b/docs/componentsguide/styles/text/index.md
@@ -82,3 +82,15 @@ Add text to shapes
 
 - **Type**: `Array`
 - **Default**: `() => [0, 0, 0, 0]`
+
+### backgroundFill
+
+- **Type**: `array`, `string`
+
+Fill color for the text background when `placement` is 'point'. Default is no fill. Either in hexadecimal or as RGBA array with red, green, and blue values betweeen 0 and 255 and alpha value between 0 and 1 inclusive.
+
+### backgroundStroke
+
+- **Type**: `Object`
+
+Stroke style for the text background when `placement` is 'point'. Default is no stroke. Please see [ol-style-stroke](/componentsguide/styles/stroke/#properties) for available options.

--- a/src/components/styles/OlStyleText.vue
+++ b/src/components/styles/OlStyleText.vue
@@ -8,7 +8,7 @@
 import type { Options, TextPlacement } from "ol/style/Text";
 import Text from "ol/style/Text";
 import Fill from "ol/style/Fill";
-import Stroke from "ol/style/Stroke";
+import Stroke, { type Options as StrokeOptions } from "ol/style/Stroke";
 
 import type { Ref } from "vue";
 import { inject, watch, onMounted, onUnmounted, provide, computed } from "vue";
@@ -16,6 +16,8 @@ import type Style from "ol/style/Style";
 import type Draw from "ol/interaction/Draw";
 import type Modify from "ol/interaction/Modify";
 import usePropsAsObjectProperties from "@/composables/usePropsAsObjectProperties";
+import type { Color } from "ol/color";
+import type { ColorLike } from "ol/colorlike";
 
 const props = withDefaults(
   defineProps<{
@@ -32,6 +34,8 @@ const props = withDefaults(
     textAlign?: CanvasTextAlign;
     textBaseline?: CanvasTextBaseline;
     padding?: [number, number, number, number];
+    backgroundFill?: Color | ColorLike;
+    backgroundStroke?: StrokeOptions;
   }>(),
   {
     maxAngle: Math.PI / 4,
@@ -54,12 +58,23 @@ const styledObj = inject<Ref<Draw | Modify | Style | null> | null>(
 
 const { properties } = usePropsAsObjectProperties(props);
 
-const createText = (innerProperties: Omit<Options, "fill" | "stroke">) => {
-  return new Text({
+const createText = (properties: typeof props) => {
+  const innerProperties = properties as Omit<
+    Options,
+    "fill" | "stroke" | "backgroundFill" | "backgroundStroke"
+  >;
+  const options: Options = {
     ...innerProperties,
     fill: new Fill(),
     stroke: new Stroke(),
-  });
+  };
+  if (properties.backgroundFill) {
+    options.backgroundFill = new Fill({ color: properties.backgroundFill });
+  }
+  if (properties.backgroundStroke) {
+    options.backgroundStroke = new Stroke(properties.backgroundStroke);
+  }
+  return new Text(options);
 };
 
 const textContent = computed(() => createText(properties));


### PR DESCRIPTION
Hey! First of all, thanks for this awesome library! :)

One thing I was missing is the ability to set `backgroundFill` and `backgroundStroke` options of [ol/style/Text](https://openlayers.org/en/latest/apidoc/module-ol_style_Text.html), so I added it.

## Description

- I added a new `backgroundFill` prop. It's type is `Color | ColorLike` so it's easy to pass just a color when using the component.
- I added a new `backgroundStoke` prop. It's type is `StrokeOptions`. When using the component, we can pass a plain object with proper fields.
- I had to modify the `createText` function's signature to be able to accept the new props. Originally it accepted a form of `Options` as argument, but since the 2 new props doesn't match that, I had to change to the type of this component's props.
- Modified the `createText` function to exclude the 2 new props as well from innerProperties, then add them as needed to Text's options.

Usage:

```html
<ol-style-text
  background-fill="yellow"
  :background-stroke="{ color: 'orange', width: 2 }"
  text="Hello"
/>
```

I considered alternative approaches to add these 2 text style parameters, but found this one the easiest to implement and fit in the library.

Alternative B would be to add an `as-background` prop to `ol-style-fill` and `ol-style-stroke`, make them check if they are inside an `ol-style-text`, and depending on these 2 they can decide whether to call `setFill/setStroke` or `setBackgroundFill/setBackgroundStroke`. The problem with this is that if the `as-background` prop is removed, they cannot set the visual style of Text reliably. They can only set it back to default, but if there's another `ol-style-fill` or `ol-style-stroke` besides the current one inside an `ol-style-text` slot, the visual style will be inconsistent.

Alternative C would be to add new `ol-style-background-fill` and `ol-style-background-stroke` components which would only set the background fill and stroke, and only inside an `ol-style-text`. I found this also unnecessary complex and confusing as `backgroundFill` and `backgroundStroke` only exist in `ol/style/Text` in OpenLayers.

However, I see that my current approach has a disadvantage that stroke options are squeezed into one prop.

Please say if you have a different view on how this feature should be added in the library and I can try to update the PR accordingly.

## Motivation and Context

`OlStyleText` already implemented all of `ol/style/Text`'s attributes except these 2, and it would be nice if we could set the background style of the texts too with this library.

## How Has This Been Tested?

I tested it by hand during development. I ran `npm run docs:dev`, navigated to http://localhost:5173/componentsguide/styles/text/ and edited `TextDemo` to check how the text style reflects to code changes. Adding and changing `background-fill` and `background-stroke` props updates the visual style immediately, and removing them reverts the text background style to OL defaults.

Don't think these changes should affect any other parts of the library, but please advise if I have to test anything and how.

## Screenshots (if appropriate):

![image](https://github.com/MelihAltintas/vue3-openlayers/assets/3587670/99e6bf83-5c79-454b-bc16-1fdb19c2d34c)

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Other (Tooling, Dependency Updates, etc.)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

If you added a new component feature (layer, geom, source, etc.), please be sure to update the documentation:

- [ ] Add component to `output.globals` in `vite.config.ts`
- [ ] Create a `src/demos/<Component>Demo.vue`
- [ ] Create a `docs/componentsguide/<Category>/<Feature>/index.md` containing the Demo and documentation for the component
- [ ] Add the docs page to `docs/.vitepress/config.ts`
- [ ] Update the sitemap `docs/public/sitemap.xml`
