### PR TITLE
feat(ol-style-text): added fill and stroke props

### DIFF
--- a/docs/componentsguide/styles/text/index.md
+++ b/docs/componentsguide/styles/text/index.md
@@ -94,3 +94,15 @@ Fill color for the text background when `placement` is 'point'. Default is no fi
 - **Type**: `Object`
 
 Stroke style for the text background when `placement` is 'point'. Default is no stroke. Please see [ol-style-stroke](/componentsguide/styles/stroke/#properties) for available options.
+
+### fill
+
+- **Type**: `array`, `string`
+
+Fill color for the text. Default is '#333'. Either in hexadecimal or as RGBA array with red, green, and blue values betweeen 0 and 255 and alpha value between 0 and 1 inclusive.
+
+### stroke
+
+- **Type**: `Object`
+
+Stroke style for the text. Default is no stroke. Please see [ol-style-stroke](/componentsguide/styles/stroke/#properties) for available options.

--- a/src/components/styles/OlStyleText.vue
+++ b/src/components/styles/OlStyleText.vue
@@ -34,6 +34,8 @@ const props = withDefaults(
     textAlign?: CanvasTextAlign;
     textBaseline?: CanvasTextBaseline;
     padding?: [number, number, number, number];
+    fill?: Color | ColorLike;
+    stroke?: StrokeOptions;
     backgroundFill?: Color | ColorLike;
     backgroundStroke?: StrokeOptions;
   }>(),
@@ -64,10 +66,14 @@ const createText = (properties: typeof props) => {
     "fill" | "stroke" | "backgroundFill" | "backgroundStroke"
   >;
   const options: Options = {
-    ...innerProperties,
-    fill: new Fill(),
-    stroke: new Stroke(),
+    ...innerProperties
   };
+  if (properties.fill) {
+    options.fill = new Fill({ color: properties.fill });
+  }
+  if (properties.stroke) {
+    options.stroke = new Stroke(properties.stroke);
+  }
   if (properties.backgroundFill) {
     options.backgroundFill = new Fill({ color: properties.backgroundFill });
   }


### PR DESCRIPTION
Thank you for the awesome library, it has saved me a ton of work. I've been trying to style some labels over map markers, and realized that I was unable to set the color of the text nor the stroke. 

## Description

Upon further digging, I came across this [PR](https://github.com/MelihAltintas/vue3-openlayers/pull/223) so I followed the same template used there and just added the missing props.

## Motivation and Context

These two props are important to style text, and `OlStyleText` already implements those.

## How Has This Been Tested?

I tested this by pointing my project's npm to my local copy and tested the color and stroke modifications according to usage.

## Screenshots (if appropriate):
<img width="160" alt="Screenshot 2023-11-30 at 9 10 45 PM" src="https://github.com/MelihAltintas/vue3-openlayers/assets/467474/cd19257f-ca2a-4d45-a796-03f57b2d42e6">
<img width="121" alt="Screenshot 2023-11-30 at 9 11 39 PM" src="https://github.com/MelihAltintas/vue3-openlayers/assets/467474/4b9722c3-1c37-4359-a785-47c0b46c0280">
<img width="85" alt="Screenshot 2023-11-30 at 9 12 31 PM" src="https://github.com/MelihAltintas/vue3-openlayers/assets/467474/666a0107-fad3-47fe-a959-84baeaaf133f">

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Other (Tooling, Dependency Updates, etc.)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

If you added a new component feature (layer, geom, source, etc.), please be sure to update the documentation:

- [ ] Add component to `output.globals` in `vite.config.ts`
- [ ] Create a `src/demos/<Component>Demo.vue`
- [ ] Create a `docs/componentsguide/<Category>/<Feature>/index.md` containing the Demo and documentation for the component
- [ ] Add the docs page to `docs/.vitepress/config.ts`
