### PR TITLE
fix(vite): styles export

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -143,7 +143,7 @@ export default defineConfig({
           "ol-ext/featureanimation/Zoom": "Zoom$1",
         },
         assetFileNames: (assetInfo) => {
-          return assetInfo.name === "index.css"
+          return assetInfo.name === "main.css"
             ? "styles.css"
             : assetInfo.name || "";
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
in vite (or rollup or vue?) index.css was renamed to `main.css`
Therefore `dist/styles.css` is missing in npm package

## Motivation and Context

```ts
import 'vue3-openlayers/styles.css'
```
is not working like described in the documentation

## How Has This Been Tested?

checked if styles.css is generated by running `npm build`

## Screenshots (if appropriate):

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other (Tooling, Dependency Updates, etc.)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

If you added a new component feature (layer, geom, source, etc.), please be sure to update the documentation:

- [ ] Add component to `output.globals` in `vite.config.ts`
- [ ] Create a `src/demos/<Component>Demo.vue`
- [ ] Create a `docs/componentsguide/<Category>/<Feature>/index.md` containing the Demo and documentation for the component
- [ ] Add the docs page to `docs/.vitepress/config.ts`
