### PR TITLE
Upgrade ol-contextmenu to v5.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It can display maps with tiled, raster or vector layers loaded from different so
 <!-- auto-generated-peer-dependency-requirements START -->
 
 - **[ol](https://github.com/openlayers/openlayers)**: `^9.0.0`
-- **[ol-contextmenu](https://github.com/jonataswalker/ol-contextmenu)**: `^5.3.0`
+- **[ol-contextmenu](https://github.com/jonataswalker/ol-contextmenu)**: `^5.4.0`
 - **[ol-ext](https://github.com/Viglino/ol-ext)**: `^4.0.15`
 - **[vue](https://github.com/vuejs/core)**: `^3.0.0`
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -5,7 +5,7 @@ vue3-openlayers works with the following versions which must be installed as pee
 <!-- auto-generated-peer-dependency-requirements START -->
 
 - **[ol](https://github.com/openlayers/openlayers)**: `^9.0.0`
-- **[ol-contextmenu](https://github.com/jonataswalker/ol-contextmenu)**: `^5.3.0`
+- **[ol-contextmenu](https://github.com/jonataswalker/ol-contextmenu)**: `^5.4.0`
 - **[ol-ext](https://github.com/Viglino/ol-ext)**: `^4.0.15`
 - **[vue](https://github.com/vuejs/core)**: `^3.0.0`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "file-saver": "^2.0.5",
         "jspdf": "^2.5.1",
         "ol": "^9.0.0",
-        "ol-contextmenu": "^5.3.0",
+        "ol-contextmenu": "^5.4.0",
         "ol-ext": "^4.0.15",
         "proj4": "^2.10.0",
         "vue": "^3.4.21"
@@ -52,7 +52,7 @@
       },
       "peerDependencies": {
         "ol": "^9.0.0",
-        "ol-contextmenu": "^5.3.0",
+        "ol-contextmenu": "^5.4.0",
         "ol-ext": "^4.0.15",
         "vue": "^3.0.0"
       }
@@ -8507,9 +8507,9 @@
       }
     },
     "node_modules/ol-contextmenu": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ol-contextmenu/-/ol-contextmenu-5.3.0.tgz",
-      "integrity": "sha512-AO9rGKaQpLAzqpEva7mukhkWrGkL/o1s8tXPsYuYBGMoiTBbXffgTikXjTmq1m7l3gDwXWWWi6R2ROda5lgXNw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ol-contextmenu/-/ol-contextmenu-5.4.0.tgz",
+      "integrity": "sha512-F2cIwCToMAYsddnrcRvCnWAH4bp9n9LNHrDTqU3mDJMiNUw1RB4Ovz5b2FwxasLpymtkzV8ME39u+mP3IvpT6g==",
       "dependencies": {
         "tiny-emitter": "^2.1.0"
       },
@@ -8518,7 +8518,7 @@
         "npm": ">=8"
       },
       "peerDependencies": {
-        "ol": "> 7.x <= 8.x"
+        "ol": "> 7.x <= 9.x"
       }
     },
     "node_modules/ol-ext": {
@@ -18028,9 +18028,9 @@
       }
     },
     "ol-contextmenu": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ol-contextmenu/-/ol-contextmenu-5.3.0.tgz",
-      "integrity": "sha512-AO9rGKaQpLAzqpEva7mukhkWrGkL/o1s8tXPsYuYBGMoiTBbXffgTikXjTmq1m7l3gDwXWWWi6R2ROda5lgXNw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ol-contextmenu/-/ol-contextmenu-5.4.0.tgz",
+      "integrity": "sha512-F2cIwCToMAYsddnrcRvCnWAH4bp9n9LNHrDTqU3mDJMiNUw1RB4Ovz5b2FwxasLpymtkzV8ME39u+mP3IvpT6g==",
       "requires": {
         "tiny-emitter": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -76,13 +76,13 @@
     "jspdf": "^2.5.1",
     "proj4": "^2.10.0",
     "ol": "^9.0.0",
-    "ol-contextmenu": "^5.3.0",
+    "ol-contextmenu": "^5.4.0",
     "ol-ext": "^4.0.15",
     "vue": "^3.4.21"
   },
   "peerDependencies": {
     "ol": "^9.0.0",
-    "ol-contextmenu": "^5.3.0",
+    "ol-contextmenu": "^5.4.0",
     "ol-ext": "^4.0.15",
     "vue": "^3.0.0"
   },
@@ -118,10 +118,5 @@
     "vite-plugin-dts": "^3.7.3",
     "vitepress": "1.0.0-rc.45",
     "vitest": "1.3.1"
-  },
-  "overrides": {
-    "ol-contextmenu": {
-      "ol": "^9.x"
-    }
   }
 }


### PR DESCRIPTION
## Description

Upgraded the `ol-contextmenu` dependency to v5.4.0 (was v5.3.0 previously).

## Motivation and Context

Currently, setting up a project with the peerDependencies as listed in the README results in a dependency conflict because `ol=^9.0.0` is specified but ol-contextmenu 5.3.0 explicitly states `ol<=8.x`, which is fixed in the [5.4.0 version](https://github.com/jonataswalker/ol-contextmenu/releases/tag/5.4.0) that @d-koppenhagen submitted and has since been released. Therefore the `overrides` workaround in the _package.json_ is no longer necessary.

_Edit: I just realised there was already an issue for this: #308_

## How Has This Been Tested?

Honestly I haven't tested this at all, but as the upstream change doesn't change anything than this very thing, it should be fine.™️ 

I hope I did everything correctly as this is the first time I commit to this project. I'm very happy to learn about anything I missed. My first intuition was to open another issue for it, but then I thought I could as well plunge forward and fix it myself :)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [x] Other (Tooling, Dependency Updates, etc.)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

If you added a new component feature (layer, geom, source, etc.), please be sure to update the documentation:

- [ ] Add component to `output.globals` in `vite.config.ts`
- [ ] Create a `src/demos/<Component>Demo.vue`
- [ ] Create a `docs/componentsguide/<Category>/<Feature>/index.md` containing the Demo and documentation for the component
- [ ] Add the docs page to `docs/.vitepress/config.ts`
