### PR TITLE
Fix Console Warnings

### DIFF
--- a/src/components/layers/OlTileLayer.vue
+++ b/src/components/layers/OlTileLayer.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { provide } from "vue";
+import { provide, toRefs } from "vue";
 import TileLayer from "ol/layer/Tile";
 import useLayer from "@/composables/useLayer";
 import {
@@ -25,7 +25,7 @@ const props = withDefaults(
   },
 );
 
-const { layer } = useLayer(TileLayer, props);
+const { layer } = useLayer(TileLayer, toRefs(props));
 
 provide("tileLayer", layer);
 

--- a/src/composables/usePropsAsObjectProperties.ts
+++ b/src/composables/usePropsAsObjectProperties.ts
@@ -19,7 +19,7 @@ function checkAndUpdateStylePropDef<T extends Record<string, unknown>>(
   options: T,
 ) {
   if ("styles" in options) {
-    const { styles, ...rest } = toRefs(options);
+    const { styles, ...rest } = toRefs(reactive(options));
     return { style: styles, ...rest } as OlClassOptions<T>;
   } else {
     return options as OlClassOptions<T>;


### PR DESCRIPTION

## Description

- add toRefs quickfix in OlTileLayer.vue, props should not bei writeable, so I change the props to a ref. To really solve this issue it would be better to change the props to a model. But this would take a lot more time.
- make options  in usePropsAsObjectProperties.ts reactive to fix the warning in the console that it expected a reactive object and get a plain one.

## Motivation and Context

Fix issue #396 and #393 

## How Has This Been Tested?

I run the vite test and the testet it in componentsguide/layers/tilelayer/

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Tests
- [ ] Other (Tooling, Dependency Updates, etc.)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I added a new test.

If you added a new component feature (layer, geom, source, etc.), please be sure to update the documentation:

- [ ] Add component to `output.globals` in `vite.config.ts`
- [ ] Provide at least one simple snapshot test (see `test` directory)
- [ ] Create a `src/demos/<Component>Demo.vue`
- [ ] Create a `docs/componentsguide/<Category>/<Feature>/index.md` containing the Demo and documentation for the component
- [ ] Add the docs page to `docs/.vitepress/config.ts`
