### PR TITLE
Fix bug when layer's opacity is undefined.

### DIFF
--- a/src/composables/useLayer.ts
+++ b/src/composables/useLayer.ts
@@ -44,8 +44,8 @@ export default function useLayer<T extends Layer>(
       }
     }
 
-    layer.value.setOpacity(properties.opacity);
-    layer.value.setVisible(properties.visible);
+    layer.value.setOpacity(properties.opacity ?? 1);
+    layer.value.setVisible(properties.visible ?? true);
 
     if (!layerAdded.value) {
       if (layerGroup) {


### PR DESCRIPTION

## Description

Fix where opacity might sometimes be undefined. By the way, modified properties.visible.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/e5d2698f-f0a2-4666-9d32-bec1eb15e36f)

