### PR TITLE
allow :style property for ol-interaction-select

### DIFF
--- a/src/components/interaction/OlInteractionSelect.vue
+++ b/src/components/interaction/OlInteractionSelect.vue
@@ -31,8 +31,8 @@ const properties = usePropsAsObjectProperties(props);
 const select = computed(
   () =>
     new Select({
-      ...(properties as Options),
       style: new Style(),
+      ...(properties as Options),
     }),
 );
 


### PR DESCRIPTION

## Description

The :style property was always overruled with a default style. By reversing the default and the options it's now possible to add a style function

## Motivation and Context

fixes #428

## How Has This Been Tested?

I'm sorry, but for some reasons every test fails on my machine, even before I made any changes. It always fails on await this.page.waitForSelector('canvas')

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Tests
- [ ] Other (Tooling, Dependency Updates, etc.)

## Checklist:

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I added a new test.

If you added a new component feature (layer, geom, source, etc.), please be sure to update the documentation:

- [ ] Add component to `output.globals` in `vite.config.ts`
- [ ] Provide at least one simple snapshot test (see `test` directory)
- [ ] Create a `src/demos/<Component>Demo.vue`
- [ ] Create a `docs/componentsguide/<Category>/<Feature>/index.md` containing the Demo and documentation for the component
- [ ] Add the docs page to `docs/.vitepress/config.ts`
