### PR TITLE
fix(ol-map): detach map target before child unmount to prevent tile source race

### DIFF
--- a/src/components/map/OlMap.vue
+++ b/src/components/map/OlMap.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, provide, ref, watch } from "vue";
+import { onBeforeUnmount, onMounted, onUnmounted, provide, ref, watch } from "vue";
 import type { AtPixelOptions } from "ol/Map";
 import Map, { type MapOptions } from "ol/Map";
 import type { FeatureLike } from "ol/Feature";
@@ -72,10 +72,13 @@ onMounted(() => {
   }
 });
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
   if (!props.instance) {
     map?.setTarget(undefined);
   }
+});
+
+onUnmounted(() => {
   map = undefined;
 });
 

--- a/src/components/map/__test__/OlMap.spec.ts
+++ b/src/components/map/__test__/OlMap.spec.ts
@@ -1,7 +1,9 @@
 import { mount } from "@vue/test-utils";
 import OlMap from "../OlMap.vue";
 import { describe, expect, it } from "vitest";
+import { defineComponent, inject, onUnmounted, ref } from "vue";
 import { FullScreen, Zoom } from "ol/control";
+import type MapType from "ol/Map";
 
 describe("OlMap.vue", () => {
   function createComponent() {
@@ -22,5 +24,28 @@ describe("OlMap.vue", () => {
   });
   it("renders viewport DOM element", () => {
     createComponent().find(".ol-viewport").exists();
+  });
+
+  it("detaches the map target before child unmount hooks run", () => {
+    const targetDuringChildUnmount = ref<unknown>(Symbol("unset"));
+    const Child = defineComponent({
+      setup() {
+        const map = inject<MapType>("map");
+        onUnmounted(() => {
+          targetDuringChildUnmount.value = map?.getTarget();
+        });
+        return () => null;
+      },
+    });
+
+    const Parent = defineComponent({
+      components: { OlMap, Child },
+      template: "<OlMap><Child /></OlMap>",
+    });
+
+    const wrapper = mount(Parent);
+    wrapper.unmount();
+
+    expect(targetDuringChildUnmount.value).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Description

Move `OlMap` target detachment to `onBeforeUnmount` so OpenLayers rendering is stopped before child components (like tile sources) unmount.

## Motivation and Context

This fixes a teardown race reported in #447 where child source components can unmount first, and a deferred OpenLayers render path then hits a null tile source (`CanvasTileLayerRenderer.enqueueTiles`).

Closes #447

## How Has This Been Tested?

- Added a regression test in `/Users/jernejbarbaric/Projects/vue3-openlayers/src/components/map/__test__/OlMap.spec.ts` that verifies map target is already detached when child `onUnmounted` hooks run.
- Ran:
  - `npm test -- src/components/map/__test__/OlMap.spec.ts`
  - Result: passing (`3/3`)

## Screenshots (if appropriate):

N/A (console/runtime unmount race fix)

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Tests
- [ ] Other (Tooling, Dependency Updates, etc.)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I added a new test.

If you added a new component feature (layer, geom, source, etc.), please be sure to update the documentation:

- [ ] Add component to `output.globals` in `vite.config.ts`
- [ ] Provide at least one simple snapshot test (see `test` directory)
- [ ] Create a `src/demos/<Component>Demo.vue`
- [ ] Create a `docs/componentsguide/<Category>/<Feature>/index.md` containing the Demo and documentation for the component
- [ ] Add the docs page to `docs/.vitepress/config.ts`